### PR TITLE
Update deprecated language constructs

### DIFF
--- a/includes/modules/payment/ebanx.php
+++ b/includes/modules/payment/ebanx.php
@@ -37,7 +37,7 @@ class ebanx extends base
     var $code, $title, $description, $enabled, $payment;
 
     
-    function ebanx()
+    function __construct()
     {
         global $order;
         $this->code = 'ebanx';
@@ -437,7 +437,7 @@ class ebanx extends base
     
     function validaCPF($cpf)
     {   
-        $cpf = str_pad(ereg_replace('[^0-9]', '', $cpf), 11, '0', STR_PAD_LEFT);
+        $cpf = str_pad(preg_replace('/[^0-9]/', '', $cpf), 11, '0', STR_PAD_LEFT);
         
         if (strlen($cpf) != 11 || $cpf == '00000000000' || $cpf == '11111111111' || $cpf == '22222222222' || $cpf == '33333333333' || $cpf == '44444444444' || $cpf == '55555555555' || $cpf == '66666666666' || $cpf == '77777777777' || $cpf == '88888888888' || $cpf == '99999999999')
         {

--- a/includes/modules/payment/ebanx_checkout.php
+++ b/includes/modules/payment/ebanx_checkout.php
@@ -37,7 +37,7 @@ class ebanx_checkout extends base
     var $code, $title, $description, $enabled, $payment, $checkoutURL, $status, $message;
     
     // class constructor
-    function ebanx_checkout()
+    function __construct()
     {
         global $order;
         $this->code = 'ebanx_checkout';


### PR DESCRIPTION
Update all class' constructor method names to `__construct` for PHP 7.0+
and change use of the deprecated ereg_replace, using preg_replace
instead.